### PR TITLE
FIX: Fixing ClassCastException issue with js eval when running as module

### DIFF
--- a/graal-js/src/com.oracle.js.parser/src/com/oracle/js/parser/ParserContext.java
+++ b/graal-js/src/com.oracle.js.parser/src/com/oracle/js/parser/ParserContext.java
@@ -215,7 +215,7 @@ class ParserContext {
     public ParserContextBlockNode getFunctionBody(final ParserContextFunctionNode functionNode) {
         for (int i = sp - 1; i >= 0; i--) {
             if (stack[i] == functionNode) {
-                return (ParserContextBlockNode) stack[i + 1];
+                return (functionNode.getKind()  == FunctionNode.Kind.MODULE) ? (ParserContextBlockNode) stack[i + 2] : (ParserContextBlockNode) stack[i + 1];
             }
         }
         throw new AssertionError(functionNode.getName() + " not on context stack");


### PR DESCRIPTION
Fixing java.lang.ClassCastException: com.oracle.js.parser.ParserContextModuleNode cannot be cast to com.oracle.js.parser.ParserContextBlockNode

```
java.lang.ClassCastException: com.oracle.js.parser.ParserContextModuleNode cannot be cast to com.oracle.js.parser.ParserContextBlockNode
	at com.oracle.js.parser.ParserContext.getFunctionBody(ParserContext.java:202)
	at com.oracle.js.parser.Parser.markEval(Parser.java:5370)
	at com.oracle.js.parser.Parser.detectSpecialFunction(Parser.java:637)
	at com.oracle.js.parser.Parser.leftHandSideExpression(Parser.java:3341)
	at com.oracle.js.parser.Parser.unaryExpression(Parser.java:4338)
	at com.oracle.js.parser.Parser.expression(Parser.java:4520)
	at com.oracle.js.parser.Parser.conditionalExpression(Parser.java:4642)
	at com.oracle.js.parser.Parser.assignmentExpression(Parser.java:4603)
	at com.oracle.js.parser.Parser.expression(Parser.java:4489)
	at com.oracle.js.parser.Parser.expression(Parser.java:4485)
	at com.oracle.js.parser.Parser.expressionStatement(Parser.java:1808)
	at com.oracle.js.parser.Parser.statement(Parser.java:1126)
	at com.oracle.js.parser.Parser.moduleBody(Parser.java:5051)
	at com.oracle.js.parser.Parser.module(Parser.java:5003)
	at com.oracle.js.parser.Parser.parseModule(Parser.java:339)
```