### PR TITLE
Expose executor

### DIFF
--- a/graal-js/src/com.oracle.truffle.js.builtins/src/com/oracle/truffle/js/builtins/JavaInteropWorkerPrototypeBuiltins.java
+++ b/graal-js/src/com.oracle.truffle.js.builtins/src/com/oracle/truffle/js/builtins/JavaInteropWorkerPrototypeBuiltins.java
@@ -51,6 +51,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.DynamicObject;
+import com.oracle.truffle.js.builtins.JavaInteropWorkerPrototypeBuiltinsFactory.JavaInteropWorkerGetExecutorNodeGen;
 import com.oracle.truffle.js.builtins.JavaInteropWorkerPrototypeBuiltinsFactory.JavaInteropWorkerSubmitNodeGen;
 import com.oracle.truffle.js.builtins.JavaInteropWorkerPrototypeBuiltinsFactory.JavaInteropWorkerTerminateNodeGen;
 import com.oracle.truffle.js.nodes.function.JSBuiltin;
@@ -84,6 +85,7 @@ public final class JavaInteropWorkerPrototypeBuiltins extends JSBuiltinsContaine
     }
 
     public enum JavaInteropWorkerPrototype implements BuiltinEnum<JavaInteropWorkerPrototype> {
+        getExecutor(0),
         submit(2),
         terminate(0);
 
@@ -102,6 +104,8 @@ public final class JavaInteropWorkerPrototypeBuiltins extends JSBuiltinsContaine
     @Override
     protected Object createNode(JSContext context, JSBuiltin builtin, boolean construct, boolean newTarget, JavaInteropWorkerPrototype builtinEnum) {
         switch (builtinEnum) {
+            case getExecutor:
+                return JavaInteropWorkerGetExecutorNodeGen.create(context, builtin, args().withThis().fixedArgs(0).createArgumentNodes(context));
             case submit:
                 return JavaInteropWorkerSubmitNodeGen.create(context, builtin, args().withThis().fixedArgs(2).createArgumentNodes(context));
             case terminate:
@@ -109,6 +113,27 @@ public final class JavaInteropWorkerPrototypeBuiltins extends JSBuiltinsContaine
                                 args().withThis().varArgs().createArgumentNodes(context));
         }
         return null;
+    }
+
+    @ImportStatic(value = {JSJavaWorkerBuiltin.class})
+    abstract static class JavaInteropWorkerGetExecutorNode extends JSBuiltinNode {
+        JavaInteropWorkerGetExecutorNode(JSContext context, JSBuiltin builtin) {
+            super(context, builtin);
+        }
+
+        @Specialization
+        @TruffleBoundary
+        protected Object getExecutor(DynamicObject worker) {
+            return new java.util.concurrent.Executor() {
+                public void execute(Runnable command) {
+                    JSContext context = getContext();
+                    EcmaAgent mainAgent = context.getMainWorker();
+                    EcmaAgent agent = JSJavaWorkerBuiltin.getAgent(worker);
+
+                    mainAgent.execute(agent, command);
+                }
+            };
+        }
     }
 
     @ImportStatic(value = {JSJavaWorkerBuiltin.class})


### PR DESCRIPTION
I looked for a way to thread back tasks into the node event loop and I looked at the Worker code and it did more than what I needed. I just tried to do a minimal change to accomplish my goals, so don't take this pull request too seriously, it is just a formal way to show you what I tried to accomplish and to ask you some questions.

I feel like it would be nice to expose Java.Executor which would implement the [Executor](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Executor.html) interface. It would be a more basic building block than Worker (actually Worker could be implemented in javascript with this building block) and it would represent an AsyncHandle ([libuv's uv_async_t](http://docs.libuv.org/en/v1.x/async.html)) with the addition that it queues [Runnables](https://docs.oracle.com/javase/7/docs/api/java/lang/Runnable.html) on the event loop and runs them.

Also it would be nice to expose [ref](http://docs.libuv.org/en/v1.x/handle.html#c.uv_ref) and [unref](http://docs.libuv.org/en/v1.x/handle.html#c.uv_unref), so the user can decide whether the event loop should wait for something or not.