### PR TITLE
Fix a bug in the instrumentation around DeclareTag materialization for BlockScopeNode

### DIFF
--- a/graal-js/src/com.oracle.truffle.js.test.instrumentation/src/com/oracle/truffle/js/test/instrumentation/VarDeclarationsTest.java
+++ b/graal-js/src/com.oracle.truffle.js.test.instrumentation/src/com/oracle/truffle/js/test/instrumentation/VarDeclarationsTest.java
@@ -43,6 +43,7 @@ package com.oracle.truffle.js.test.instrumentation;
 import org.junit.Test;
 
 import com.oracle.truffle.js.nodes.instrumentation.JSTags.DeclareTag;
+import com.oracle.truffle.js.nodes.instrumentation.JSTags.WriteVariableExpressionTag;
 
 public class VarDeclarationsTest extends FineGrainedAccessTest {
 
@@ -100,4 +101,20 @@ public class VarDeclarationsTest extends FineGrainedAccessTest {
         }).exit();
     }
 
+    @Test
+    public void classDeclare() {
+        evalWithTags("class Foo{}", new Class<?>[]{DeclareTag.class, WriteVariableExpressionTag.class});
+
+        enter(WriteVariableExpressionTag.class, (e1, w1) -> {
+            enter(DeclareTag.class, (e2) -> {
+                assertAttribute(e2, NAME, "Foo");
+                assertAttribute(e2, TYPE, "const");
+            }).exit();
+            enter(WriteVariableExpressionTag.class, (e2, w2) -> {
+                w2.input();
+            }).exit();
+            w1.input();
+        }).exit();
+
+    }
 }

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/nodes/function/BlockScopeNode.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/nodes/function/BlockScopeNode.java
@@ -126,7 +126,7 @@ public abstract class BlockScopeNode extends JavaScriptNode implements Resumable
         public InstrumentableNode materializeInstrumentableNodes(Set<Class<? extends Tag>> materializedTags) {
             if (materializedTags.contains(DeclareTag.class) && !DeclareTagProvider.isMaterializedFrameProvider(this)) {
                 JavaScriptNode materialized = DeclareTagProvider.createMaterializedBlockNode(block, frameDescriptor, parentSlot, getSourceSection());
-                materialized.setSourceSection(this.getSourceSection());
+                transferSourceSectionAndTags(this, materialized);
                 return materialized;
             } else {
                 return this;


### PR DESCRIPTION
The ```BlockScopeNode``` needs to be materialized to get the declare event to be used in the instrumentation. Currently, only the source section is transferred from the original node to the materialized one while the tags not. This can be problematic in cases where another can depend on this node as input (the materialized node no longer has the necessary tags to be recognized as an input node).

In the PR, I have attached a test to reproduce the bug with a fix to the bug by simply transferring both source sections as well as tags of the original node. 