### PR TITLE
fix AwaitNode related instrumentation

### DIFF
--- a/graal-js/src/com.oracle.truffle.js.parser/src/com/oracle/truffle/js/parser/GraalJSTranslator.java
+++ b/graal-js/src/com.oracle.truffle.js.parser/src/com/oracle/truffle/js/parser/GraalJSTranslator.java
@@ -134,6 +134,7 @@ import com.oracle.truffle.js.nodes.control.BreakTarget;
 import com.oracle.truffle.js.nodes.control.ContinueTarget;
 import com.oracle.truffle.js.nodes.control.DiscardResultNode;
 import com.oracle.truffle.js.nodes.control.EmptyNode;
+import com.oracle.truffle.js.nodes.control.GeneratorExprBlockNode;
 import com.oracle.truffle.js.nodes.control.GeneratorWrapperNode;
 import com.oracle.truffle.js.nodes.control.ResumableNode;
 import com.oracle.truffle.js.nodes.control.ReturnNode;
@@ -694,6 +695,9 @@ abstract class GraalJSTranslator extends com.oracle.js.parser.ir.visitor.Transla
             genBlock = returnsResult ? factory.createGeneratorExprBlock(chunks, readState, writeState) : factory.createGeneratorVoidBlock(chunks, readState, writeState);
         }
         JavaScriptNode.transferSourceSectionAndTags(blockNode, genBlock);
+        if (genBlock instanceof GeneratorExprBlockNode && !genBlock.hasSourceSection()) {
+            tagHiddenExpression(genBlock);
+        }
         return genBlock;
     }
 
@@ -727,6 +731,7 @@ abstract class GraalJSTranslator extends com.oracle.js.parser.ir.visitor.Transla
         } else if (child instanceof JavaScriptNode) {
             String identifier = ":generatorexpr:" + environment.getFunctionFrameDescriptor().getSize();
             LazyReadFrameSlotNode readState = factory.createLazyReadFrameSlot(identifier);
+            tagHiddenExpression(readState);
             JavaScriptNode writeState = factory.createLazyWriteFrameSlot(identifier, (JavaScriptNode) child);
             if (NodeUtil.isReplacementSafe(parent, child, readState)) {
                 environment.getFunctionFrameDescriptor().addFrameSlot(identifier);

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/nodes/control/AwaitNode.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/nodes/control/AwaitNode.java
@@ -204,6 +204,11 @@ public class AwaitNode extends JavaScriptNode implements ResumableNode, SuspendN
     }
 
     @Override
+    public Object getNodeObject() {
+        return JSTags.createNodeObjectDescriptor("type", JSTags.ControlFlowBranchTag.Type.Await.name());
+    }
+
+    @Override
     public Object resume(VirtualFrame frame) {
         int index = getStateAsInt(frame);
         if (index == 0) {

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/nodes/control/GeneratorWrapperNode.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/nodes/control/GeneratorWrapperNode.java
@@ -78,6 +78,10 @@ public final class GeneratorWrapperNode extends JavaScriptNode implements Repeat
         if (tag == JSTags.ControlFlowBranchTag.class) {
             return true;
         }
+        Node child = childNode instanceof WrapperNode ? ((WrapperNode) childNode).getDelegateNode() : childNode;
+        if ((child instanceof AwaitNode) && tag == JSTags.InputNodeTag.class) {
+            return true;
+        }
         return super.hasTag(tag);
     }
 


### PR DESCRIPTION
Fix issues when ```AwaitNode``` is used as input for another node.

According to the [logic](https://github.com/graalvm/graaljs/blob/0e309309f5d5f91ccf640a455fe0d3847608569c/graal-js/src/com.oracle.truffle.js.parser/src/com/oracle/truffle/js/parser/GraalJSTranslator.java#L613-L642) in Graal.js translator, there are two cases where the await node can be used as inputs for another node.

## Case 1 

Example: ```let val = await 42:``` 
In this case, ```GeneratorWrapper``` is used directly as the input for the write node.

## Case 2:
Example: ```return await 42 + await 43; ```
In this case, the binary node is replaced with a ```GeneratorExprBlockNode```, and the left and right nodes of the binary node has been replaced with two internal reads of the ```:generatorexpr``` slots.
We need to make sure both the binary node and the return node has the correct input(s).