### PR TITLE
Fixed instrumentation related to async/await

### DIFF
--- a/graal-js/src/com.oracle.truffle.js.parser/src/com/oracle/truffle/js/parser/GraalJSTranslator.java
+++ b/graal-js/src/com.oracle.truffle.js.parser/src/com/oracle/truffle/js/parser/GraalJSTranslator.java
@@ -432,6 +432,7 @@ abstract class GraalJSTranslator extends com.oracle.js.parser.ir.visitor.Transla
             body = handleFunctionReturn(functionNode, body);
 
             if (isAsyncFunction) {
+                ensureHasSourceSection(body, functionNode);
                 body = handleAsyncFunctionBody(body, currentFunction.getFunctionName());
             }
         }

--- a/graal-js/src/com.oracle.truffle.js.test.instrumentation/src/com/oracle/truffle/js/test/instrumentation/AsyncFunctionTest.java
+++ b/graal-js/src/com.oracle.truffle.js.test.instrumentation/src/com/oracle/truffle/js/test/instrumentation/AsyncFunctionTest.java
@@ -55,6 +55,69 @@ public class AsyncFunctionTest extends FineGrainedAccessTest {
         assertSimpleAsyncFunction("(async () => { return 42; })();");
     }
 
+    @Test
+    public void asyncFunctionWithAwait() {
+        String src = "(async function foo(v) { if (v < 1) {return await foo(v+1);} else {return 42;} })(0);";
+        evalWithTags(src, new Class<?>[]{JSTags.ControlFlowRootTag.class, JSTags.ControlFlowBranchTag.class});
+        // enter foo the first time
+        enter(JSTags.ControlFlowRootTag.class, (e, i) -> {
+            // this is the async function
+            assertAttribute(e, TYPE, JSTags.ControlFlowRootTag.Type.AsyncFunction.name());
+            // if statement
+            enter(JSTags.ControlFlowRootTag.class, (e1, i1) -> {
+                assertAttribute(e1, TYPE, JSTags.ControlFlowRootTag.Type.Conditional.name());
+                // condition true
+                enter(JSTags.ControlFlowBranchTag.class, (e2, i2) -> {
+                    assertAttribute(e2, TYPE, JSTags.ControlFlowBranchTag.Type.Condition.name());
+                    i2.input(true);
+                }).exit();
+                i1.input(true);
+                // return statement
+                enter(JSTags.ControlFlowBranchTag.class, (e4, i4) -> {
+                    assertAttribute(e4, TYPE, JSTags.ControlFlowBranchTag.Type.Return.name());
+                    // await
+                    enter(JSTags.ControlFlowBranchTag.class, (e5, i5) -> {
+                        assertAttribute(e5, TYPE, JSTags.ControlFlowBranchTag.Type.Await.name());
+                        // enter foo again
+                        enter(JSTags.ControlFlowRootTag.class, (e6, i6) -> {
+                            assertAttribute(e, TYPE, JSTags.ControlFlowRootTag.Type.AsyncFunction.name());
+                            // if statement
+                            enter(JSTags.ControlFlowRootTag.class, (e7, i7) -> {
+                                // condition false
+                                enter(JSTags.ControlFlowBranchTag.class, (e8, i8) -> {
+                                    i8.input(false);
+                                }).exit();
+                                i7.input(false);
+                                // return 42;
+                                enter(JSTags.ControlFlowBranchTag.class, (e9, i9) -> {
+                                    assertAttribute(e4, TYPE, JSTags.ControlFlowBranchTag.Type.Return.name());
+                                    i9.input(42);
+                                }).exit();
+                                i7.input(42);
+                            }).exit();
+                        }).exit();
+                        // await got the promise, we can ignore the extra input
+                        i5.input(assertJSPromiseInput);
+                        i5.input(assertJSPromiseInput);
+                    }).exitMaybeControlFlowException();
+                }).exitMaybeControlFlowException();
+            }).exitMaybeControlFlowException();
+        }).exit();
+        // resumed
+        enter(JSTags.ControlFlowRootTag.class, (e, i) -> {
+            assertAttribute(e, TYPE, JSTags.ControlFlowRootTag.Type.Conditional.name());
+            enter(JSTags.ControlFlowBranchTag.class, (e1, i1) -> {
+                assertAttribute(e1, TYPE, JSTags.ControlFlowBranchTag.Type.Return.name());
+                enter(JSTags.ControlFlowBranchTag.class, (e2, i2) -> {
+                    assertAttribute(e2, TYPE, JSTags.ControlFlowBranchTag.Type.Await.name());
+                    i2.input(42);
+                }).exit();
+                i1.input(42);
+            }).exitMaybeControlFlowException();
+            i.input(42);
+        }).exitMaybeControlFlowException();
+    }
+
     private void assertSimpleAsyncFunction(String src) {
         evalWithTag(src, JSTags.ControlFlowRootTag.class);
 

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/nodes/JSNodeUtil.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/nodes/JSNodeUtil.java
@@ -49,6 +49,7 @@ import com.oracle.truffle.api.nodes.NodeUtil;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.nodes.SlowPathException;
 import com.oracle.truffle.api.source.SourceSection;
+import com.oracle.truffle.js.nodes.control.GeneratorWrapperNode;
 import com.oracle.truffle.js.nodes.function.FunctionRootNode;
 import com.oracle.truffle.js.runtime.util.DebugCounter;
 
@@ -126,6 +127,6 @@ public final class JSNodeUtil {
 
     public static boolean hasExactlyOneRootBodyTag(JavaScriptNode body) {
         CompilerAsserts.neverPartOfCompilation();
-        return NodeUtil.countNodes(body, node -> node instanceof JavaScriptNode && ((JavaScriptNode) node).hasTag(RootBodyTag.class)) == 1;
+        return NodeUtil.countNodes(body, node -> !(node instanceof GeneratorWrapperNode) && node instanceof JavaScriptNode && ((JavaScriptNode) node).hasTag(RootBodyTag.class)) == 1;
     }
 }

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/nodes/control/AwaitNode.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/nodes/control/AwaitNode.java
@@ -134,7 +134,7 @@ public class AwaitNode extends JavaScriptNode implements ResumableNode, SuspendN
 
     @Override
     public boolean hasTag(Class<? extends Tag> tag) {
-        if (tag == JSTags.ControlFlowBranchTag.class) {
+        if (tag == JSTags.ControlFlowBranchTag.class || tag == JSTags.InputNodeTag.class) {
             return true;
         }
         return super.hasTag(tag);

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/nodes/control/GeneratorWrapperNode.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/nodes/control/GeneratorWrapperNode.java
@@ -41,17 +41,13 @@
 package com.oracle.truffle.js.nodes.control;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.instrumentation.InstrumentableNode;
 import com.oracle.truffle.api.instrumentation.Tag;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RepeatingNode;
 import com.oracle.truffle.js.nodes.JavaScriptNode;
 import com.oracle.truffle.js.nodes.access.WriteNode;
-import com.oracle.truffle.js.nodes.instrumentation.JSTags;
 import com.oracle.truffle.js.runtime.Errors;
 import com.oracle.truffle.js.runtime.objects.Undefined;
-
-import java.util.Set;
 
 public final class GeneratorWrapperNode extends JavaScriptNode implements RepeatingNode {
     @Child private JavaScriptNode childNode;
@@ -67,41 +63,28 @@ public final class GeneratorWrapperNode extends JavaScriptNode implements Repeat
 
     public static JavaScriptNode createWrapper(JavaScriptNode child, JavaScriptNode readStateNode, WriteNode writeStateNode) {
         JavaScriptNode wrapper = new GeneratorWrapperNode(child, readStateNode, writeStateNode);
-        if (child instanceof AwaitNode) {
-            wrapper.setSourceSection(child.getSourceSection());
-        }
+        Node realChild = child instanceof WrapperNode ? ((WrapperNode) child).getDelegateNode() : child;
+        wrapper.setSourceSection(realChild.getSourceSection());
         return wrapper;
     }
 
     @Override
     public boolean hasTag(Class<? extends Tag> tag) {
-        if (tag == JSTags.ControlFlowBranchTag.class) {
-            return true;
-        }
-        if (tag == JSTags.InputNodeTag.class) {
-            Node child = childNode instanceof WrapperNode ? ((WrapperNode) childNode).getDelegateNode() : childNode;
-            if (child instanceof AwaitNode) {
-                return true;
-            }
+        Node child = childNode instanceof WrapperNode ? ((WrapperNode) childNode).getDelegateNode() : childNode;
+        if (child instanceof JavaScriptNode) {
+            return ((JavaScriptNode) child).hasTag(tag);
         }
         return super.hasTag(tag);
     }
 
     @Override
     public Object getNodeObject() {
-        return JSTags.createNodeObjectDescriptor("type", JSTags.ControlFlowBranchTag.Type.Await.name());
-    }
-
-    @Override
-    public InstrumentableNode materializeInstrumentableNodes(Set<Class<? extends Tag>> materializedTags) {
-        if (materializedTags.contains(JSTags.ControlFlowBranchTag.class)) {
-            if (childNode instanceof AwaitNode) {
-                GeneratorWrapperNode materialized = new GeneratorWrapperNode(childNode, stateNode, writeStateNode);
-                transferSourceSection(this, materialized);
-                return materialized;
-            }
+        Node child = childNode instanceof WrapperNode ? ((WrapperNode) childNode).getDelegateNode() : childNode;
+        if (child instanceof JavaScriptNode) {
+            return ((JavaScriptNode) child).getNodeObject();
+        } else {
+            return null;
         }
-        return this;
     }
 
     @Override

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/nodes/instrumentation/JSTaggedExecutionNode.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/nodes/instrumentation/JSTaggedExecutionNode.java
@@ -76,6 +76,14 @@ public final class JSTaggedExecutionNode extends JavaScriptNode {
     }
 
     private static JavaScriptNode createImpl(JavaScriptNode originalNode, JavaScriptNode transferSourcesFrom, Class<? extends Tag> expectedTag, boolean inputTag, NodeObjectDescriptor descriptor) {
+        // check if the node has already been tagged
+        JavaScriptNode realOriginal = originalNode;
+        if (originalNode instanceof WrapperNode) {
+            realOriginal = (JavaScriptNode) ((WrapperNode) originalNode).getDelegateNode();
+        }
+        if (realOriginal.hasTag(expectedTag) && (!inputTag || realOriginal.hasTag(JSTags.InputNodeTag.class))) {
+            return originalNode;
+        }
         JavaScriptNode clone = cloneUninitialized(originalNode);
         JavaScriptNode wrapper = new JSTaggedExecutionNode(clone, expectedTag, inputTag, descriptor);
         transferSourceSection(transferSourcesFrom, wrapper);


### PR DESCRIPTION
- Update ```GeneratorWrapper``` to take over the instrumentation responsibility of its child ```childNode```.
- Added check when creating ```JSTaggedExecutionNode``` to skip when the node already has the required tag.
- Ensure the ```functionBody``` child node of  ```AsyncFunctionBodyNode``` has its source section set before constructing the `sure``AsyncFunctionBodyNode``` so that we don't miss the events for async functions.
- Improved ```FineGrainedAccessTest```, i.e. the instrumentation tests' harness