### PR TITLE
node crashes when --help is passed

### DIFF
--- a/graal-nodejs/deps/uv/include/uv.h
+++ b/graal-nodejs/deps/uv/include/uv.h
@@ -23,6 +23,11 @@
 
 #ifndef UV_H
 #define UV_H
+
+#ifndef __cplusplus
+#include <stdbool.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -1651,7 +1656,7 @@ UV_EXTERN const char* uv_dlerror(const uv_lib_t* lib);
 
 UV_EXTERN int uv_mutex_init(uv_mutex_t* handle);
 UV_EXTERN int uv_mutex_init_recursive(uv_mutex_t* handle);
-UV_EXTERN void uv_mutex_destroy(uv_mutex_t* handle);
+UV_EXTERN void uv_mutex_destroy(uv_mutex_t* handle, bool abort_on_error);
 UV_EXTERN void uv_mutex_lock(uv_mutex_t* handle);
 UV_EXTERN int uv_mutex_trylock(uv_mutex_t* handle);
 UV_EXTERN void uv_mutex_unlock(uv_mutex_t* handle);

--- a/graal-nodejs/deps/uv/src/threadpool.c
+++ b/graal-nodejs/deps/uv/src/threadpool.c
@@ -176,7 +176,7 @@ UV_DESTRUCTOR(static void cleanup(void)) {
   if (threads != default_threads)
     uv__free(threads);
 
-  uv_mutex_destroy(&mutex);
+  uv_mutex_destroy(&mutex, true);
   uv_cond_destroy(&cond);
 
   threads = NULL;

--- a/graal-nodejs/deps/uv/src/unix/loop.c
+++ b/graal-nodejs/deps/uv/src/unix/loop.c
@@ -95,7 +95,7 @@ int uv_loop_init(uv_loop_t* loop) {
   return 0;
 
 fail_async_init:
-  uv_mutex_destroy(&loop->wq_mutex);
+  uv_mutex_destroy(&loop->wq_mutex, true);
 
 fail_mutex_init:
   uv_rwlock_destroy(&loop->cloexec_lock);
@@ -162,7 +162,7 @@ void uv__loop_close(uv_loop_t* loop) {
   assert(QUEUE_EMPTY(&loop->wq) && "thread pool work queue not empty!");
   assert(!uv__has_active_reqs(loop));
   uv_mutex_unlock(&loop->wq_mutex);
-  uv_mutex_destroy(&loop->wq_mutex);
+  uv_mutex_destroy(&loop->wq_mutex, true);
 
   /*
    * Note that all thread pool stuff is finished at this point and

--- a/graal-nodejs/src/node_options.cc
+++ b/graal-nodejs/src/node_options.cc
@@ -22,7 +22,7 @@ using v8::Value;
 namespace node {
 
 namespace per_process {
-Mutex cli_options_mutex;
+Mutex cli_options_mutex(false); // It might be destroyed in spite of holding lock (e.g. --help)
 std::shared_ptr<PerProcessOptions> cli_options{new PerProcessOptions()};
 }  // namespace per_process
 


### PR DESCRIPTION
I saw Node.js in GraalVM crashed when I pass `--help` option to `node` as below:

```
$ $GRAALVM_HOME/bin/node --help

Usage: node [options] [ -e script | script.js ] [arguments]

  :

See http://www.graalvm.org for more information.
Aborted (core dumped)
```

Backtrace is here:

```
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007fcccd756895 in __GI_abort () at abort.c:79
#2  0x0000000000544a38 in uv_mutex_destroy (mutex=<optimized out>)
    at ../deps/uv/src/unix/thread.c:325
#3  0x00007fcccd7703d7 in __run_exit_handlers (status=0, listp=0x7fcccd8f4578 <__exit_funcs>,
    run_list_atexit=run_list_atexit@entry=true, run_dtors=run_dtors@entry=true) at exit.c:108
#4  0x00007fcccd770580 in __GI_exit (status=<optimized out>) at exit.c:139
#5  0x00007fccc1075339 in JVM_Halt (retcode=<optimized out>)
    at /home/yasuenag/github/graal/substratevm/src/com.oracle.svm.native.jvm.posix/src/JvmFuncs.c:182
#6  0x00007fccbfc5279e in ?? ()
   from /home/yasuenag/github/graal/sdk/mxbuild/linux-amd64/GRAALVM_CE_JAVA11/graalvm-ce-java11-20.2.0-dev/lib/polyglot/libpolyglot.so
#7  0x00007fccbfc52628 in ?? ()
   from /home/yasuenag/github/graal/sdk/mxbuild/linux-amd64/GRAALVM_CE_JAVA11/graalvm-ce-java11-20.2.0-dev/lib/polyglot/libpolyglot.so
#8  0x00007fccbf90ebbc in ?? ()
   from /home/yasuenag/github/graal/sdk/mxbuild/linux-amd64/GRAALVM_CE_JAVA11/graalvm-ce-java11-20.2.0-dev/lib/polyglot/libpolyglot.so
#9  0x0000000006ba9cd0 in ?? ()
#10 0x00007fccc7ec35d0 in ?? ()
   from /home/yasuenag/github/graal/sdk/mxbuild/linux-amd64/GRAALVM_CE_JAVA11/graalvm-ce-java11-20.2.0-dev/lib/polyglot/libpolyglot.so
#11 0x00007fcccd3131c0 in ?? ()
#12 0x00007fccbf912a32 in ?? ()
   from /home/yasuenag/github/graal/sdk/mxbuild/linux-amd64/GRAALVM_CE_JAVA11/graalvm-ce-java11-20.2.0-dev/lib/polyglot/libpolyglot.so
#13 0x00007fccbf8e963c in ?? ()
   from /home/yasuenag/github/graal/sdk/mxbuild/linux-amd64/GRAALVM_CE_JAVA11/graalvm-ce-java11-20.2.0-dev/lib/polyglot/libpolyglot.so
#14 0x00007fccbf8ed657 in ?? ()
   from /home/yasuenag/github/graal/sdk/mxbuild/linux-amd64/GRAALVM_CE_JAVA11/graalvm-ce-java11-20.2.0-dev/lib/polyglot/libpolyglot.so
#15 0x00007fccbe1dac61 in ?? ()
   from /home/yasuenag/github/graal/sdk/mxbuild/linux-amd64/GRAALVM_CE_JAVA11/graalvm-ce-java11-20.2.0-dev/lib/polyglot/libpolyglot.so
#16 0x00000000008474f5 in GraalIsolate::GraalIsolate(JavaVM_*, JNIEnv_*, v8::Isolate::CreateParams const&) ()
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
```

This error is caused by mutex in Node.js .

Node.js acquires `cli_options_mutex` when it performs for option strings, and Java method is called without releasing it.

When `--help` is passed, process would exit from Java, and the mutex would be destroyed at exit handler. `uv_mutex_destroy()` would call `abort()` when `pthread_mutex_destroy()` fails. 

`cli_options_mutex` is still hold when the process exits from Java! So node process crashes when `--help` is finished.