### PR TITLE
Process name of Node.js is empty in jps

### DIFF
--- a/graal-nodejs/deps/v8/src/graal/graal_isolate.cc
+++ b/graal-nodejs/deps/v8/src/graal/graal_isolate.cc
@@ -390,6 +390,9 @@ v8::Isolate* GraalIsolate::New(v8::Isolate::CreateParams const& params, v8::Isol
         options.push_back({const_cast<char*>("-XX:HeapBaseMinAddress=24g"), nullptr});
     #endif
 
+        // Set process name (it would be shown in jcmd, jps)
+        options.push_back({const_cast<char*>("-Dsun.java.command=graal-nodejs"), nullptr});
+
     #if defined(DEBUG)
         std::string debugPort = getstdenv("DEBUG_PORT");
         if (!debugPort.empty()) {

--- a/graal-nodejs/deps/v8/src/graal/graal_isolate.cc
+++ b/graal-nodejs/deps/v8/src/graal/graal_isolate.cc
@@ -391,7 +391,7 @@ v8::Isolate* GraalIsolate::New(v8::Isolate::CreateParams const& params, v8::Isol
     #endif
 
         // Set process name (it would be shown in jcmd, jps)
-        options.push_back({const_cast<char*>("-Dsun.java.command=graal-nodejs"), nullptr});
+        options.push_back({const_cast<char*>("-Dsun.java.command=node"), nullptr});
 
     #if defined(DEBUG)
         std::string debugPort = getstdenv("DEBUG_PORT");


### PR DESCRIPTION
I tried to check all JVM process in the system with `jps` and `jcmd`, but I couldn't see Node.js process which was started with `--jvm` option at a glance as below:

```
$ jcmd
167394 sun.tools.jcmd.JCmd
167359
```

PID 167359 is Node.js process. Main class is empty.

`jps` and `jcmd` refer `sun.java.command` system property.  
graal-nodejs should set it like a Java launcher in OpenJDK.