### PR TITLE
Add missing CORE_MODULES.

### DIFF
--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/commonjs/CommonJSResolution.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/commonjs/CommonJSResolution.java
@@ -80,11 +80,12 @@ final class CommonJSResolution {
     public static final String PACKAGE_JSON_TYPE_PROPERTY_NAME = "type";
     public static final String PACKAGE_JSON_MODULE_VALUE = "module";
 
-    private static final String[] CORE_MODULES = new String[]{"assert", "async_hooks", "buffer", "child_process", "cluster", "crypto",
-                    "dgram", "dns", "domain", "events", "fs", "http", "http2", "https", "module", "net",
-                    "os", "path", "perf_hooks", "punycode", "querystring", "readline", "repl",
-                    "stream", "string_decoder", "tls", "trace_events", "tty", "url", "util",
-                    "v8", "vm", "worker_threads", "zlib"};
+    private static final String[] CORE_MODULES = new String[]{"assert", "async_hooks", "buffer", "child_process",
+                    "cluster", "console", "constants", "crypto", "dgram", "diagnostics_channel", "dns", "domain",
+                    "events", "fs", "http", "http2", "https", "inspector", "module", "net", "os", "path",
+                    "perf_hooks", "process", "punycode", "querystring", "readline", "repl", "stream",
+                    "string_decoder", "sys", "timers", "tls", "trace_events", "tty", "url", "util", "v8", "vm",
+                    "wasi", "worker_threads", "zlib"};
 
     private CommonJSResolution() {
     }


### PR DESCRIPTION
Updated missing modules based on those in nodejs's lib:
https://github.com/nodejs/node/tree/master/lib

The missing modules seem to be causing issues with loading their associated polyfills via `js.commonjs-core-modules-replacements`.

For reference these are the modules I've added:
```
console
constants
diagnostics_channel
inspector
process
sys
timers
wasi
```